### PR TITLE
Update nokogiri to 1.8.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,7 +52,7 @@ GEM
       rake
     mini_portile2 (2.3.0)
     minitest (5.10.2)
-    nokogiri (1.8.2)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     open4 (1.3.4)
     parallel (1.12.0)
@@ -117,4 +117,4 @@ DEPENDENCIES
   simpleidn (~> 0.0.6)
 
 BUNDLED WITH
-   1.16.1
+   1.16.6


### PR DESCRIPTION
https://rubysec.com/advisories/nokogiri-CVE-2018-14404