### PR TITLE
Allow WhoisRecord with reserved status to be both active/inactive

### DIFF
--- a/app/models/whois_record.rb
+++ b/app/models/whois_record.rb
@@ -7,11 +7,14 @@ class WhoisRecord < ActiveRecord::Base
   DISCARDED = 'deleteCandidate'.freeze
   AT_AUCTION = 'AtAuction'.freeze
   PENDING_REGISTRATION = 'PendingRegistration'.freeze
+  DISPUTED = 'Disputed'.freeze
 
   TEMPLATE_DIR = File.join(File.dirname(__FILE__), '../views/whois_record/').freeze
   TEMPLATE_INACTIVE = (TEMPLATE_DIR + "inactive.erb").freeze
   LEGAL_PERSON_TEMPLATE = (TEMPLATE_DIR + "legal_person.erb").freeze
   PRIVATE_PERSON_TEMPLATE = (TEMPLATE_DIR + "private_person.erb").freeze
+
+  INACTIVE_STATUSES = [BLOCKED, DISCARDED, AT_AUCTION, PENDING_REGISTRATION].freeze
 
   def unix_body
     file = File.new(template)
@@ -38,6 +41,12 @@ class WhoisRecord < ActiveRecord::Base
     json['tech_contacts'].map { |serialized_contact| deserialize_contact(serialized_contact) }
   end
 
+  def active?
+    return false if json['registered'].nil?
+
+    (json['status'] & INACTIVE_STATUSES).empty?
+  end
+
   private
 
   def deserialize_registrant
@@ -60,9 +69,5 @@ class WhoisRecord < ActiveRecord::Base
     else
       LEGAL_PERSON_TEMPLATE
     end
-  end
-
-  def active?
-    (([BLOCKED, RESERVED, DISCARDED, AT_AUCTION, PENDING_REGISTRATION] & json['status']).empty?)
   end
 end

--- a/test/models/whois_record_test.rb
+++ b/test/models/whois_record_test.rb
@@ -65,4 +65,35 @@ class WhoisRecordTest < Minitest::Test
 
     assert_equal expected_output, @whois_record.unix_body
   end
+
+  def test_reserved_record_is_active_if_registered
+    @whois_record = WhoisRecord.new(name: 'shop.test',
+      json: { name: 'shop.test',
+              registered: Time.now,
+              status: [WhoisRecord::RESERVED] })
+    assert @whois_record.active?
+  end
+
+  def test_reserved_record_is_inactive_if_unregistered
+    @whois_record = WhoisRecord.new(name: 'shop.test',
+      json: { name: 'shop.test',
+              status: [WhoisRecord::RESERVED] })
+    assert !@whois_record.active?
+  end
+
+  def test_disputed_record_is_active_if_registered
+    @whois_record = WhoisRecord.new(name: 'shop.test',
+      json: { name: 'shop.test',
+              registered: Time.now,
+              status: [WhoisRecord::DISPUTED] })
+    assert @whois_record.active?
+  end
+
+  def test_disputed_record_is_inactive_if_unregistered
+    @whois_record = WhoisRecord.new(name: 'shop.test',
+      json: { name: 'shop.test',
+              status: [WhoisRecord::DISPUTED] })
+    assert !@whois_record.active?
+  end
+
 end


### PR DESCRIPTION
Closes #15

Fixed behaviour for WhoisRecord with reserved state, domain can be active/inactive with reserved status. As disputed status works the same way, it works out of the box in a way described in [registry#269](https://github.com/internetee/registry/issues/269)