### PR TITLE
adjust WHOIS regex to allow 1-letter second-level domains (SLD) in WH…

### DIFF
--- a/lib/whois_server.rb
+++ b/lib/whois_server.rb
@@ -24,8 +24,8 @@ end
 module WhoisServer
   include Logging
 
-  DOMAIN_NAME_REGEXP = /\A[a-z0-9\-\u00E4\u00F5\u00F6\u00FC\u0161\u017E]{2,61}\.
-    ([a-z0-9\-\u00E4\u00F5\u00F6\u00FC\u0161\u017E]{2,61}\.)?[a-z0-9]{1,61}\z/x.freeze
+  DOMAIN_NAME_REGEXP = /\A[a-z0-9\-\u00E4\u00F5\u00F6\u00FC\u0161\u017E]{1,61}\.
+    ([a-z0-9\-\u00E4\u00F5\u00F6\u00FC\u0161\u017E]{1,61}\.)?[a-z0-9]{1,61}\z/x.freeze
 
   def dbconfig
     return @dbconfig unless @dbconfig.nil?

--- a/lib/whois_server.rb
+++ b/lib/whois_server.rb
@@ -131,7 +131,9 @@ module WhoisServer
   end
 end
 
-EventMachine.run do
-  EventMachine.start_server ENV['HOST'] || '0.0.0.0', ENV['PORT'] || '43', WhoisServer
-  EventMachine.set_effective_user ENV['WHOIS_USER'] || `whoami`.strip
+if $PROGRAM_NAME == __FILE__
+  EventMachine.run do
+    EventMachine.start_server ENV['HOST'] || '0.0.0.0', ENV['PORT'] || '43', WhoisServer
+    EventMachine.set_effective_user ENV['WHOIS_USER'] || `whoami`.strip
+  end
 end

--- a/test/whois_server_test.rb
+++ b/test/whois_server_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+module EventMachine
+    def self.run; end
+    def self.start_server(*args); end
+    def self.set_effective_user(*args); end
+end
+
+require_relative "../lib/whois_server"
+
+class WhoisServerTest < ActiveSupport::TestCase
+    def test_allows_one_letter_domain
+        assert_match WhoisServer::DOMAIN_NAME_REGEXP, "a.ee"
+        assert_match WhoisServer::DOMAIN_NAME_REGEXP, "õ.ee"
+        assert_match WhoisServer::DOMAIN_NAME_REGEXP, "1.ee"
+        refute_match WhoisServer::DOMAIN_NAME_REGEXP, "a..ee"
+        assert_match WhoisServer::DOMAIN_NAME_REGEXP, "ab.ee"
+    end
+end    

--- a/test/whois_server_test.rb
+++ b/test/whois_server_test.rb
@@ -1,19 +1,20 @@
-require "test_helper"
+# frozen_string_literal: true
+require 'test_helper'
 
 module EventMachine
-    def self.run; end
-    def self.start_server(*args); end
-    def self.set_effective_user(*args); end
+  def self.run; end
+  def self.start_server(*args); end
+  def self.set_effective_user(*args); end
 end
 
-require_relative "../lib/whois_server"
+require_relative '../lib/whois_server'
 
 class WhoisServerTest < ActiveSupport::TestCase
-    def test_allows_one_letter_domain
-        assert_match WhoisServer::DOMAIN_NAME_REGEXP, "a.ee"
-        assert_match WhoisServer::DOMAIN_NAME_REGEXP, "õ.ee"
-        assert_match WhoisServer::DOMAIN_NAME_REGEXP, "1.ee"
-        refute_match WhoisServer::DOMAIN_NAME_REGEXP, "a..ee"
-        assert_match WhoisServer::DOMAIN_NAME_REGEXP, "ab.ee"
-    end
-end    
+  def test_allows_one_letter_domain
+    assert_match WhoisServer::DOMAIN_NAME_REGEXP, 'a.ee'
+    assert_match WhoisServer::DOMAIN_NAME_REGEXP, 'õ.ee'
+    assert_match WhoisServer::DOMAIN_NAME_REGEXP, '1.ee'
+    refute_match WhoisServer::DOMAIN_NAME_REGEXP, 'a..ee'
+    assert_match WhoisServer::DOMAIN_NAME_REGEXP, 'ab.ee'
+  end
+end


### PR DESCRIPTION
## Summary

Adjusted the WHOIS server domain name regex to allow **1-letter domain labels**.  
This ensures WHOIS queries like `whois a.ee` or `whois x.ee` are correctly accepted and processed.

---

## What was changed?

- Updated `DOMAIN_NAME_REGEXP` in `lib/whois_server.rb` to:
  - lower the minimum length for the first and optional second labels from `2` to `1`
- This enables WHOIS lookups for single-character second-level domains (SLDs) that previously failed validation.

---

## Why was this needed?

- The `.ee` registry has already completed English-style auctions for previously reserved 1-letter SLDs, and these domains are now registered and active in DNS.
- Our REST WHOIS API already handled these queries, but traditional WHOIS queries over port 43 (e.g. using CLI tools like `whois a.ee`) failed due to outdated validation rules requiring at least 2 characters.
- This update aligns the WHOIS service with the current state of the `.ee` namespace and ensures consistent results across both WHOIS interfaces.
