### PR TITLE
Refactor: extract domain regex to shared module and fix test

### DIFF
--- a/lib/whois_server.rb
+++ b/lib/whois_server.rb
@@ -9,6 +9,7 @@ require 'yaml'
 require_relative '../app/models/whois_record'
 require_relative '../app/validators/unicode_validator'
 require_relative 'logging'
+require_relative 'whois_server_core'
 
 # This module extends the YAML module to properly load files with aliases.
 module YAML
@@ -24,8 +25,7 @@ end
 module WhoisServer
   include Logging
 
-  DOMAIN_NAME_REGEXP = /\A[a-z0-9\-\u00E4\u00F5\u00F6\u00FC\u0161\u017E]{1,61}\.
-    ([a-z0-9\-\u00E4\u00F5\u00F6\u00FC\u0161\u017E]{1,61}\.)?[a-z0-9]{1,61}\z/x.freeze
+  DOMAIN_NAME_REGEXP = WhoisServerCore::DOMAIN_NAME_REGEXP
 
   def dbconfig
     return @dbconfig unless @dbconfig.nil?
@@ -131,9 +131,7 @@ module WhoisServer
   end
 end
 
-if $PROGRAM_NAME == __FILE__
-  EventMachine.run do
-    EventMachine.start_server ENV['HOST'] || '0.0.0.0', ENV['PORT'] || '43', WhoisServer
-    EventMachine.set_effective_user ENV['WHOIS_USER'] || `whoami`.strip
-  end
+EventMachine.run do
+  EventMachine.start_server ENV['HOST'] || '0.0.0.0', ENV['PORT'] || '43', WhoisServer
+  EventMachine.set_effective_user ENV['WHOIS_USER'] || `whoami`.strip
 end

--- a/lib/whois_server_core.rb
+++ b/lib/whois_server_core.rb
@@ -1,0 +1,4 @@
+module WhoisServerCore
+  DOMAIN_NAME_REGEXP = /\A[a-z0-9\-\u00E4\u00F5\u00F6\u00FC\u0161\u017E]{1,61}\.
+  ([a-z0-9\-\u00E4\u00F5\u00F6\u00FC\u0161\u017E]{1,61}\.)?[a-z0-9]{1,61}\z/x.freeze
+end

--- a/test/whois_server_test.rb
+++ b/test/whois_server_test.rb
@@ -1,20 +1,12 @@
-# frozen_string_literal: true
-require 'test_helper'
+require 'minitest/autorun'
+require_relative '../lib/whois_server_core'
 
-module EventMachine
-  def self.run; end
-  def self.start_server(*args); end
-  def self.set_effective_user(*args); end
-end
-
-require_relative '../lib/whois_server'
-
-class WhoisServerTest < ActiveSupport::TestCase
+class WhoisServerTest < Minitest::Test
   def test_allows_one_letter_domain
-    assert_match WhoisServer::DOMAIN_NAME_REGEXP, 'a.ee'
-    assert_match WhoisServer::DOMAIN_NAME_REGEXP, 'õ.ee'
-    assert_match WhoisServer::DOMAIN_NAME_REGEXP, '1.ee'
-    refute_match WhoisServer::DOMAIN_NAME_REGEXP, 'a..ee'
-    assert_match WhoisServer::DOMAIN_NAME_REGEXP, 'ab.ee'
+    assert_match WhoisServerCore::DOMAIN_NAME_REGEXP, 'a.ee'
+    assert_match WhoisServerCore::DOMAIN_NAME_REGEXP, 'õ.ee'
+    assert_match WhoisServerCore::DOMAIN_NAME_REGEXP, '1.ee'
+    refute_match WhoisServerCore::DOMAIN_NAME_REGEXP, 'a..ee'
+    assert_match WhoisServerCore::DOMAIN_NAME_REGEXP, 'ab.ee'
   end
 end


### PR DESCRIPTION
## Summary

This pull request resolves a test and runtime failure introduced in [#173](https://github.com/internetee/whois/pull/173), where the updated domain name regex allowing 1-character SLDs was implemented directly in `whois_server.rb`.  

Due to the way our `systemd` service launches the server (using `ruby whois.rb start -t`), the main execution block was not triggered (`if $PROGRAM_NAME == __FILE__`), causing both **Test WHOIS and Production WHOIS to fail silently**.

---

## What was changed?

- Extracted the `DOMAIN_NAME_REGEXP` constant into a shared module: `lib/whois_server_core.rb`
- Updated both `lib/whois_server.rb` and `whois_server_test.rb` to reference the shared constant
- Ensured the `EventMachine.run` block executes even when launched via `systemd`, by removing reliance on `$PROGRAM_NAME == __FILE__`

---

## Why was this needed?

- After [PR #173](https://github.com/internetee/whois/pull/173), the regex logic was correct and shared across environments
- However, the WHOIS server failed to start because `systemd` invoked the script in a way that bypassed the main execution block
- This caused:
  - **Silent failure in production**
  - **No service response in Test WHOIS**
- This PR ensures:
  - **Runtime correctness**: server start logic is reliably executed regardless of how the script is invoked
  - **Test stability**: tests continue to validate against the actual production logic
  - **Code maintainability**: regex is now imported from a single source

---

## Testing & Verification

- Changes were tested on our Test WHOIS instance
- After updating the startup logic, the WHOIS service now correctly responds to 1-letter SLD queries (e.g. `whois a.ee`)
- All Minitest cases pass

---
