### PR TITLE
updated ruby version from 3.4.2 to 3.4.4 in workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04]
-        ruby: ['3.4.2']
+        ruby: ['3.4.4']
     runs-on: ${{ matrix.os }}
     env:
       PG_DATABASE: postgres


### PR DESCRIPTION
According to renovate security update from Ruby v 3.4.2 to 3.4.4 https://github.com/internetee/whois/pull/171 it is required to update ruby version also in workflow.