### PR TITLE
Automated pull request merging

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,64 @@
+name: auto-merge
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, labeled]
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Check PR merge-conditions
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const botUsers = ['dependabot[bot]', 'snyk-bot'];
+            if (!botUsers.includes(pr.user.login)) {
+              core.notice('Author is not a bot – skip auto-merge');
+              return;
+            }
+            const title = pr.title.toLowerCase();
+            const body = (pr.body || '').toLowerCase();
+            const isPin = /\bpin\b/i.test(title) || /\bpin\b/i.test(body);
+            const isDigest = /\bdigest\b/i.test(title) || /\bdigest\b/i.test(body);
+            if (isPin || isDigest) {
+              core.notice(`PR is ${isPin ? 'pin' : 'digest'} update – merge allowed`);
+              return;
+            }
+            const regex = /from\s+v?(\d+(?:\.\d+)+)\s+to\s+v?(\d+(?:\.\d+)+)/i;
+            const match = title.match(regex);
+            if (!match) {
+              core.notice('No version pattern found – skip auto-merge');
+              return;
+            }
+            const fromVersion = match[1];
+            const toVersion = match[2];
+            core.notice(`Detected version change: ${fromVersion} → ${toVersion}`);
+            function isPatchUpdate(from, to) {
+              const fromParts = from.split('.').map(Number);
+              const toParts = to.split('.').map(Number);
+              if (fromParts.length !== toParts.length) return false;
+              for (let i = 0; i < fromParts.length - 1; i++) {
+                if (fromParts[i] !== toParts[i]) return false;
+              }
+              return fromParts[fromParts.length - 1] !== toParts[toParts.length - 1];
+            }
+            const isPatch = isPatchUpdate(fromVersion, toVersion);
+            if (!isPatch) {
+              core.notice('PR is NOT a patch update – auto-merge not allowed');
+              return;
+            }
+            core.notice('Patch update detected – merge allowed');
+      - name: Enable auto-merge
+        if: ${{ success() && github.event.pull_request.merged == false &&
+              (github.event.pull_request.user.login == 'dependabot[bot]' ||
+               github.event.pull_request.user.login == 'snyk-bot') }}
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          merge-method: squash
+          merge-commit-message: "chore: auto-merge by ${{ github.actor }} - ${{ github.event.pull_request.title }}"

--- a/renovate.json
+++ b/renovate.json
@@ -4,8 +4,8 @@
   ],
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": false,
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
       "automergeType": "pr"
     },
     {


### PR DESCRIPTION
This update will merge Pull Requests with patch updates automatically to master branch.
Requirements:

    Pull requests are made by 'dependabot' or 'renovate bot'
    Pull request is 'patch' version either 1.2.3 -> 1.2.4 or 1.2.3.4 -> 1.2.3.5
    All tests are passed
    Pull Request is up to date with master branch

Minor and Major updates(snyk) for security are not included for auto merge.

NB! After merging this update it is required to set for this repo:

    Settings > General > Pull Requests "Allow auto-merge"
    Settings > Branches > Add rule :

    Require status checks to pass before merging
    Require branches to be up to date before merging
    test (ubuntu-24.04, 3.4.4)